### PR TITLE
[feat] category 엔티티 추가

### DIFF
--- a/src/main/java/primitive/community/app/domain/category/entity/Category.java
+++ b/src/main/java/primitive/community/app/domain/category/entity/Category.java
@@ -1,0 +1,31 @@
+package primitive.community.app.domain.category.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@ToString
+@Table(name = "category")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false)
+    @Comment("이름")
+    private String name;
+}

--- a/src/main/java/primitive/community/app/domain/category/entity/Category.java
+++ b/src/main/java/primitive/community/app/domain/category/entity/Category.java
@@ -28,4 +28,12 @@ public class Category {
     @Column(nullable = false)
     @Comment("이름")
     private String name;
+
+    @Column(nullable = false)
+    @Comment("계층")
+    private int depth;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "upperCategoryId")
+    private Category name;
 }

--- a/src/main/java/primitive/community/app/domain/post/entity/Post.java
+++ b/src/main/java/primitive/community/app/domain/post/entity/Post.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Comment;
+import primitive.community.app.domain.category.entity.Category;
 import primitive.community.app.domain.member.entity.Member;
 
 @Entity
@@ -31,13 +32,14 @@ public class Post {
     @Comment("멤버")
     private Member member;
 
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    @Comment("카테고리")
+    private Category category;
+
     @Column(nullable = false)
     @Comment("제목")
     private String title;
-
-    @Column(nullable = false)
-    @Comment("카테고리")
-    private String category;
 
     @Comment("내용")
     private String content;


### PR DESCRIPTION
## Issue Link
- closes #3

## To Reviewers
- 카테고리별 분류 기능 및 카테고리 CRUD 기능을 위해 카테고리 테이블을 따로 분리했습니다.
- 기존에 Post 엔티티에 text 필드로 들어가 있던 카테고리를 엔티티로 분리했습니다. 
- Category 엔티티의 필드로 이름만 넣었습니다. 추 후 추가 협의가 필요합니다.

## Reference 
